### PR TITLE
Fixing a crash and fixing Table.Row.cells accessibility.

### DIFF
--- a/iOSBellaDatiSDK/KpiLabel.swift
+++ b/iOSBellaDatiSDK/KpiLabel.swift
@@ -32,8 +32,8 @@ public class KpiLabel:View {
         public var caption = String()
         public var style = String()
         public var numberValue = String()
-        public var color = UIColor()
-        public var backgroundcolor = UIColor()
+        public var color = UIColor.black
+        public var backgroundcolor = UIColor.clear
         public var fontweight = String()
         
     

--- a/iOSBellaDatiSDK/KpiLabel.swift
+++ b/iOSBellaDatiSDK/KpiLabel.swift
@@ -354,13 +354,10 @@ public class KpiLabel:View {
                 let parsedstylevalues = self.parseValueStyle(style: style)
                 
                 
-                kpiLabelValue.color = UIColor(red: CGFloat(parsedstylevalues.color.red/255) , green: CGFloat(parsedstylevalues.color.green/255), blue:CGFloat(parsedstylevalues.color.blue/255) , alpha: 1.0)
+                kpiLabelValue.color = UIColor(red: CGFloat(parsedstylevalues.color.red) / 255.0, green: CGFloat(parsedstylevalues.color.green) / 255.0, blue: CGFloat(parsedstylevalues.color.blue) / 255.0, alpha: 1.0)
                 
-                
-                
-                
-                kpiLabelValue.backgroundcolor = UIColor(red: CGFloat(parsedstylevalues.backgroundcolor.red/255) , green: CGFloat(parsedstylevalues.backgroundcolor.green/255), blue:CGFloat(parsedstylevalues.backgroundcolor.blue/255) , alpha: 1.0)
-                
+				kpiLabelValue.backgroundcolor = UIColor(red: CGFloat(parsedstylevalues.backgroundcolor.red) / 255.0, green: CGFloat(parsedstylevalues.backgroundcolor.green) / 255.0, blue: CGFloat(parsedstylevalues.backgroundcolor.blue) / 255.0, alpha: 1.0)
+				
                 kpiLabelValue.fontweight = parsedstylevalues.fontweight
                 
                 self.values?.append(kpiLabelValue)

--- a/iOSBellaDatiSDK/Table.swift
+++ b/iOSBellaDatiSDK/Table.swift
@@ -398,11 +398,11 @@ public class Table:View {
                         let parsedstylevalues = self.parseValueStyle(style: style)
                         
                         
-                        cellobject.color = UIColor(red: CGFloat(parsedstylevalues.color.red/255) , green: CGFloat(parsedstylevalues.color.green/255), blue:CGFloat(parsedstylevalues.color.blue/255) , alpha: 1.0)
-                        
-                        cellobject.backgroundcolor = UIColor(red: CGFloat(parsedstylevalues.backgroundcolor.red/255) , green: CGFloat(parsedstylevalues.backgroundcolor.green/255), blue:CGFloat(parsedstylevalues.backgroundcolor.blue/255) , alpha: 1.0)
-                    
-                    
+						cellobject.color = UIColor(red: CGFloat(parsedstylevalues.color.red) / 255.0, green: CGFloat(parsedstylevalues.color.green) / 255.0, blue: CGFloat(parsedstylevalues.color.blue) / 255.0, alpha: 1.0)
+						
+						cellobject.backgroundcolor = UIColor(red: CGFloat(parsedstylevalues.backgroundcolor.red) / 255.0, green: CGFloat(parsedstylevalues.backgroundcolor.green) / 255.0, blue: CGFloat(parsedstylevalues.backgroundcolor.blue) / 255.0, alpha: 1.0)
+						
+						
                     }
                     
                     rowobject.cells.append(cellobject)
@@ -438,10 +438,10 @@ public class Table:View {
                         let parsedstylevalues = self.parseValueStyle(style: style)
                         
                         
-                        cellobject.color = UIColor(red: CGFloat(parsedstylevalues.color.red/255) , green: CGFloat(parsedstylevalues.color.green/255), blue:CGFloat(parsedstylevalues.color.blue/255) , alpha: 1.0)
+                        cellobject.color = UIColor(red: CGFloat(parsedstylevalues.color.red) / 255.0, green: CGFloat(parsedstylevalues.color.green) / 255.0, blue: CGFloat(parsedstylevalues.color.blue) / 255.0, alpha: 1.0)
                         
-                        cellobject.backgroundcolor = UIColor(red: CGFloat(parsedstylevalues.backgroundcolor.red/255) , green: CGFloat(parsedstylevalues.backgroundcolor.green/255), blue:CGFloat(parsedstylevalues.backgroundcolor.blue/255) , alpha: 1.0)
-                        
+						cellobject.backgroundcolor = UIColor(red: CGFloat(parsedstylevalues.backgroundcolor.red) / 255.0, green: CGFloat(parsedstylevalues.backgroundcolor.green) / 255.0, blue: CGFloat(parsedstylevalues.backgroundcolor.blue) / 255.0, alpha: 1.0)
+						
                         
                         
                         

--- a/iOSBellaDatiSDK/Table.swift
+++ b/iOSBellaDatiSDK/Table.swift
@@ -31,8 +31,8 @@ public class Table:View {
         public var value  = String("")
         public var type = "cell" // value for regular cells
         public var style = String() // style available for cells of type="cell" otherwise empty String object
-        public var color = UIColor()
-        public var backgroundcolor = UIColor()
+        public var color = UIColor.black
+        public var backgroundcolor = UIColor.clear
         
         public init(){
             
@@ -85,7 +85,7 @@ public class Table:View {
     
     public class Row {
         
-        var cells = [Cell]()
+        public var cells = [Cell]()
         
         public init(){
             


### PR DESCRIPTION
- Using UIColor() creates a UIPlaceholder color which will cause the app to crash when used.
- Table.Row.cells were internal and hence inaccessible from out of the framework.
