### PR TITLE
Adding public intializers

### DIFF
--- a/iOSBellaDatiSDK/DataSetData.swift
+++ b/iOSBellaDatiSDK/DataSetData.swift
@@ -23,7 +23,9 @@ public class DataSetData{
     public var lastChange: String?
     
     
-    
+    public init() {
+      
+    }
     
     
     /* Downloads DataSetInfo and Data for Attributes and Indicators. Including Row unique number*/

--- a/iOSBellaDatiSDK/Domain.swift
+++ b/iOSBellaDatiSDK/Domain.swift
@@ -20,7 +20,9 @@ public class Domain {
     public var parameters:[String:String]?
     
     
-    
+    public init() {
+      
+    }
     
     
     


### PR DESCRIPTION
Adding public intializers as they are internal by default, disallowing instantiation outside of the framework.