### PR TITLE
Using an ephemeral configuration for URLSession.

### DIFF
--- a/iOSBellaDatiSDK/APIClient.swift
+++ b/iOSBellaDatiSDK/APIClient.swift
@@ -37,7 +37,7 @@ public class APIClient {
     private let encoding = String.Encoding.utf8
     private var oauthParams = [String:String]()
     private var oauthHandler: OAuth1a!
-    private let session =  URLSession.shared
+    private let session =  URLSession(configuration: URLSessionConfiguration.ephemeral)
     private var o_authtoken: String?
     
     


### PR DESCRIPTION
The shared URLSession uses caching and may cache old data for faster loads. This data, however, may be outdated. The ephemeral URLSessionConfiguration will disable any caching.