### PR TITLE
Fixing a crash in APIClient

### DIFF
--- a/iOSBellaDatiSDK/APIClient.swift
+++ b/iOSBellaDatiSDK/APIClient.swift
@@ -158,8 +158,13 @@ public class APIClient {
                 
                 return
             }
-            let responseBody =  NSString(data: data!, encoding: self.encoding.rawValue)! as String
             
+            guard let bodyData = data, let responseBody = String(data: bodyData, encoding: self.encoding) else {
+            				// Either data is nil, or we can't use this encoding for reading
+            				// the data into string.
+            				completionBlock?(NSError(domain: NSCocoaErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "Received invalid data."]))
+            				return
+            }
             
             let httpResponse = response as! HTTPURLResponse
             let statusCode = httpResponse.statusCode


### PR DESCRIPTION
If the received data could not be interpreted with `self.encoding`, or if the received data was `nil` for some reason, the SDK would cause a crash instead of gracefully informing about an error.