### PR TITLE
Prevent a crash pulling User info.

### DIFF
--- a/iOSBellaDatiSDK/User.swift
+++ b/iOSBellaDatiSDK/User.swift
@@ -124,10 +124,15 @@ import UIKit
             {
                 APIClient.sharedInstance.authenticateWithBellaDati(){(error) -> Void in
                     print("handlin stuff")
-                    if let receivedError = error
-                    {
+                                                                     
+                    // We have encountered an error, do not load any additional data
+                    // as we failed to authenticate.
+                    if let receivedError = error {
                         print(receivedError)
+                    				completion?()
+                    				return
                     }
+
                     
                     getData()
                     


### PR DESCRIPTION
If we fail to authenticate with BellaDati, do not go through with loading data as that leads to a crash in `APIClient.apiRequest(...)` which assumes a non-nil OAuth token.